### PR TITLE
Update README.md: launch command error

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ Once downloaded, the Gradio demo can be run using these checkpoints.
 
 For model with MusicGen
 ```
-python gradio_app.py --model ./ckpts/M2UGen-MusicGen --llama_dir ./ckpts/LLaMA-2 --music_decoder musicgen
+python gradio_app.py --model ./ckpts/M2UGen-MusicGen/checkpoint.pth --llama_dir ./ckpts/LLaMA-2 --music_decoder musicgen
 ```
 
 For model with AudioLDM2
 ```
-python gradio_app.py --model ./ckpts/M2UGen-AudioLDM2 --llama_dir ./ckpts/LLaMA-2 --music_decoder audioldm2
+python gradio_app.py --model ./ckpts/M2UGen-AudioLDM2/checkpoint.pth  --llama_dir ./ckpts/LLaMA-2 --music_decoder audioldm2  --music_decoder_path cvssp/audioldm2
 ```
 
 ## 🗄️ Dataset Generation


### PR DESCRIPTION
Thank you for this meaningful work.  But there may be some errors in this README.md.

First, I set up my environment according to the README.md file, and my directory structure is the same as below:

```
├── ...
├── M2UGen                
│   ├── ckpts
│   │   │── LLaMA
│   │   │   │── 7B
│   │   │   │   │── checklist.chk
│   │   │   │   │── consolidated.00.pth
│   │   │   │   │── params.json
│   │   │   │── tokenizer.model
│   │   │   │── tokenizer_checklist.chk
│   │   │── M2UGen-MusicGen
│   │   │   │── checkpoint.pth
│   │   │── M2UGen-AudioLDM2
│   │   │   │── checkpoint.pth
```

Howerver, when I use the given command `python gradio_app.py --model ./ckpts/M2UGen-AudioLDM2 --llama_dir ./ckpts/LLaMA-2 --music_decoder audioldm2` to launch the gradio, it encountered some errors:

1. The `--model` parameter is error, because the ` ./ckpts/M2UGen-AudioLDM2` is the a folder.
2. The `--music_decoder_path` parameter is error, because the default value is `facebook/musicgen-medium`, which will make it error when we use the `audioldm2`.

So I believe it will be better if we update the command in the README.md for others to better use this repo.